### PR TITLE
ppx_inline_alcotest dependency

### DIFF
--- a/ego.opam
+++ b/ego.opam
@@ -19,6 +19,7 @@ depends: [
   "ocamldot" {>= "1.1"}
   "sexplib" {>= "v0.14.0"}
   "odoc" {with-doc}
+  "ppx_inline_alcotest" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
I'm using ego with esy and it fails to build without this dependency.