### PR TITLE
Fix e-matching algorithm for basic.ml

### DIFF
--- a/lib/basic.ml
+++ b/lib/basic.ml
@@ -391,38 +391,30 @@ module EGraph = struct
 
   (* ** Matching *)
   let ematch eg classes pattern =
+    let concat_map f l = Iter.concat (Iter.map f l) in
     let rec enode_matches p enode env =
       match[@warning "-8"] p,enode with
       | Query.(Q (f, _), (f', _)) when not @@ (Equal.map Symbol.repr Equal.int) f f' ->
-        None
+        Iter.empty
       | (Q (_, args), (_, args')) ->
         (fun f -> List.iter2 (Fun.curry f) args args')
-        |> Iter.fold_while (fun env (qvar, trm) ->
-          match env with
-          | None -> None, `Stop
-          | Some env ->
-            match match_in qvar trm env with
-            | Some _ as res -> res, `Continue
-            | None -> None, `Stop
-        ) (Some env)
+        |> Iter.fold (fun envs (qvar, trm) ->
+          concat_map (fun env' -> match_in qvar trm env') envs) (Iter.singleton env)
     and match_in p eid env =
       let eid = find eg eid in
       match p with
       | V id -> begin
           match StringMap.find_opt id env with
-          | None -> Some (StringMap.add id eid env)
-          | Some eid' when Id.eq_id eid eid' -> Some env
-          | _ -> None
+          | None -> Iter.singleton (StringMap.add id eid env)
+          | Some eid' when Id.eq_id eid eid' -> Iter.singleton env
+          | _ -> Iter.empty
         end
       | p ->
         Vector.to_iter (Id.Map.find classes eid)
-        |> Iter.find_map (fun enode -> enode_matches p enode env) in
+        |> concat_map (fun enode -> enode_matches p enode env) in
     (fun f -> Id.Map.iter (Fun.curry f) classes)
-    |> Iter.filter_map (fun (eid,_) ->
-      match match_in pattern eid StringMap.empty with
-      | Some env -> Some ((eid, env))
-      | _ -> None
-    )
+    |> concat_map (fun (eid, _) ->
+        Iter.map (fun s -> (eid, s)) (match_in pattern eid StringMap.empty))
 
   (* ** Rewriting System *)
   let apply_rules eg rules =
@@ -470,15 +462,14 @@ let%test "test egraph matching" =
   Alcotest.(check int) "(g ?a) has 2 matches"
     2 (List.length matches)
 
-(*
 let%test "test egraph matching" =
   let g = EGraph.init () in
   let g1 = EGraph.add_sexp g [%s g 1] in
   let g2 = EGraph.add_sexp g [%s g 2] in
   let g3 = EGraph.add_sexp g [%s g 3] in
-  let f1 = EGraph.add_sexp g [%s (f 1 (g 1))] in
-  let f2 = EGraph.add_sexp g [%s (f 2 (g 2))] in
-  let f3 = EGraph.add_sexp g [%s (f 3 (g 3))] in
+  let f1 = EGraph.add_sexp g [%s (f 1 (g 2))] in
+  let f2 = EGraph.add_sexp g [%s (f 2 (g 3))] in
+  let f3 = EGraph.add_sexp g [%s (f 3 (g 1))] in
   EGraph.merge g g1 g2;
   EGraph.merge g g2 g3;
   EGraph.merge g f1 f2;
@@ -488,4 +479,3 @@ let%test "test egraph matching" =
   let matches = EGraph.ematch g (EGraph.eclasses g) query |> Iter.to_list in
   Alcotest.(check int) "has 3 matches"
     3 (List.length matches)
-*)

--- a/lib/basic.ml
+++ b/lib/basic.ml
@@ -457,3 +457,35 @@ module EGraph = struct
 
 
 end
+
+let%test "test egraph matching" =
+  let g = EGraph.init () in
+  let g1 = EGraph.add_sexp g [%s g 1] in
+  let g2 = EGraph.add_sexp g [%s g 2] in
+  EGraph.merge g g1 g2;
+  EGraph.rebuild g;
+  let query = Query.of_sexp [%s g "?a"] in
+  let matches = EGraph.ematch g (EGraph.eclasses g) query |> Iter.to_list in
+  (* Should have two matches: (g 1) and (g 2) *)
+  Alcotest.(check int) "(g ?a) has 2 matches"
+    2 (List.length matches)
+
+(*
+let%test "test egraph matching" =
+  let g = EGraph.init () in
+  let g1 = EGraph.add_sexp g [%s g 1] in
+  let g2 = EGraph.add_sexp g [%s g 2] in
+  let g3 = EGraph.add_sexp g [%s g 3] in
+  let f1 = EGraph.add_sexp g [%s (f 1 (g 1))] in
+  let f2 = EGraph.add_sexp g [%s (f 2 (g 2))] in
+  let f3 = EGraph.add_sexp g [%s (f 3 (g 3))] in
+  EGraph.merge g g1 g2;
+  EGraph.merge g g2 g3;
+  EGraph.merge g f1 f2;
+  EGraph.merge g f2 f3;
+  EGraph.rebuild g;
+  let query = Query.of_sexp [%s f "?a" (g "?a")] in
+  let matches = EGraph.ematch g (EGraph.eclasses g) query |> Iter.to_list in
+  Alcotest.(check int) "has 3 matches"
+    3 (List.length matches)
+*)

--- a/lib/dune
+++ b/lib/dune
@@ -3,8 +3,8 @@
  (public_name ego)
  (libraries containers iter dot containers-data sexplib)
  (inline_tests)
- (preprocess (pps ppx_inline_alcotest ppx_deriving.std)))
+ (preprocess (pps ppx_sexp ppx_inline_alcotest ppx_deriving.std)))
 
 (env
  (dev  
-   (flags (:standard -w -58))))
+   (flags (:standard -w -58 -warn-error -A))))

--- a/lib/dune
+++ b/lib/dune
@@ -7,4 +7,4 @@
 
 (env
  (dev  
-   (flags (:standard -w -58 -warn-error -A))))
+   (flags (:standard -w -58))))

--- a/test/test_basic.ml
+++ b/test/test_basic.ml
@@ -32,8 +32,52 @@ let documentation_example () =
     [%s ((a * 2) / 2)]
     result
 
+(*
+      We start off with two exprs, (g 1) and (g 2), and merge these two.
+      Then we add a rule (g ?a) -> (h ?a), creating (h 1) and (h 2) which are also equal to (g 1) and (g 2).
+      We extract the cheapest term using a cost function constructed such that (h 2) is lowest cost term, with cost 11.
+      However, (h 1), which has cost 12, is extracted instead.
+
+      (h 1): 12
+      (h 2): 11
+      (g 1): inf
+      (g 2): inf
+*)
+let test_match () =
+  let graph = EGraph.init () in
+  let expr_id1 = EGraph.add_sexp graph [%s (g 1)] in
+  let _ = EGraph.add_sexp graph [%s (g 2)] in
+  let from = Query.of_sexp [%s (g 1)]
+  and into = Query.of_sexp [%s (g 2)] in
+  let rule1 = Rule.make ~from ~into |> function
+  | Some rule -> rule
+  | None -> Alcotest.fail "could not build rule" in
+  let from = Query.of_sexp [%s (g "?a")]
+  and into = Query.of_sexp [%s (h "?a")] in
+  let rule2 = Rule.make ~from ~into |> function
+  | Some rule -> rule
+  | None -> Alcotest.fail "could not build rule" in
+  Alcotest.(check bool)
+    "should reach equality saturation"
+    true (EGraph.run_until_saturation graph [rule1; rule2]);
+  let cost_function score (sym, children) =
+    let node_score =
+      match Symbol.to_string sym with
+      | "g" -> 9999999.
+      | "h" -> 10.
+      | "1" -> 2.
+      | "2" -> 1.
+      | _ -> 9999999. in
+    node_score +. List.fold_left (fun acc vl -> acc +. score vl) 0. children in
+  let result = EGraph.extract cost_function graph expr_id1 in
+  Alcotest.(check sexp)
+    "cheapest expression is (h 2)"
+    [%s (h 2)]
+    result
+
 
 let () =
   Alcotest.run "basic" [
-    ("documentation", ["example given in documentation works as written", `Quick, documentation_example])
+    ("documentation", ["example given in documentation works as written", `Quick, documentation_example]);
+    ("test matching", ["test matching", `Quick, test_match])
   ]

--- a/test/test_basic.ml
+++ b/test/test_basic.ml
@@ -36,7 +36,7 @@ let documentation_example () =
       We start off with two exprs, (g 1) and (g 2), and merge these two.
       Then we add a rule (g ?a) -> (h ?a), creating (h 1) and (h 2) which are also equal to (g 1) and (g 2).
       We extract the cheapest term using a cost function constructed such that (h 2) is lowest cost term, with cost 11.
-      However, (h 1), which has cost 12, is extracted instead.
+      Previously (h 1), which has cost 12, was extracted instead.
 
       (h 1): 12
       (h 2): 11


### PR DESCRIPTION
I believe I found a bug in the implementation of e-matching in `basic.ml`. I have found instances where e-matching does not match all valid expressions in the e-graph, and thus rewrites are not correctly performed. I created the failing tests on my fork [here](https://github.com/tmoux/ego/commit/8877d045197e00152d7516c460b71a055c5212f4).

[Test 1](https://github.com/tmoux/ego/blob/8877d045197e00152d7516c460b71a055c5212f4/lib/basic.ml#L461): I created an egraph with the expressions `(g 1)` and `(g 2)`, and then merged these two. Then, I rebuilt the egraph and called `EGraph.ematch` on the query `(g ?a)`, expecting two matches, but only getting one. Note that there are two matches, as expected, if we do not merge `(g 1)` and `(g 2)`.

[Test 2](https://github.com/tmoux/ego/blob/8877d045197e00152d7516c460b71a055c5212f4/test/test_basic.ml#L46): To ensure that this was not caused by inadvertently breaking any internal invariants of the egraph, I created another test that only uses the public interface of the egraph. Here, I again created an egraph with `(g 1)` and `(g 2)` and merged them, and then I applied the rewrite `(g ?a) => (h ?a)`. This should create the expressions `(h 1)` and `(h 2)`, which are both equivalent to `(g 1)` and `(g 2)`. However, due to the bug previously shown, I think `(h 2)` is actually not created. I then designed a cost function such that `(h 2)` would be the cheapest term to extract, but `(h 1)` was returned instead. I wrote an equivalent test in [egg](https://github.com/egraphs-good/egg) and confirmed that extracting `(h 2)` should be the intended behavior.

The fix seems to be straightforward. The issue is that for a given enode/eclass, there can be
multiple valid substitutions for the same pattern (for instance, for the query `(g ?a)` in the first test case, both `a=1` and `a=2` are valid substitutions). Thus, the helper functions `enode_matches` and `match_in` should return a list/iter of substitutions rather than an option.

This patch passes all existing tests, as well as a few inline tests I added that previously failed due to `ematch` not finding all the substitutions. Note that the e-matching algorithm in `generic.ml` seems largely the same, and probably has to be fixed as well.