### PR TITLE
Fix e-matching in generic.ml

### DIFF
--- a/lib/basic.ml
+++ b/lib/basic.ml
@@ -410,8 +410,10 @@ module EGraph = struct
           | _ -> Iter.empty
         end
       | p ->
-        Vector.to_iter (Id.Map.find classes eid)
-        |> concat_map (fun enode -> enode_matches p enode env) in
+        match Id.Map.find_opt classes eid with
+        | Some v -> Vector.to_iter v |> concat_map (fun enode -> enode_matches p enode env)
+        | None -> Iter.empty
+      in
     (fun f -> Id.Map.iter (Fun.curry f) classes)
     |> concat_map (fun (eid, _) ->
         Iter.map (fun s -> (eid, s)) (match_in pattern eid StringMap.empty))

--- a/test/test_math.ml
+++ b/test/test_math.ml
@@ -416,7 +416,7 @@ let () =
        check_proves_equal ~node_limit:(`Bounded 100_000) ~fuel:(`Bounded 35) rules
          [%s (d x (1 + (2. * x)))]  [%s 2. ];
        "dx/dy of xy + 1 is y", `Quick,
-       check_extract ~node_limit:(`Unbounded) ~fuel:(`Bounded 100) rules
+       check_extract ~node_limit:(`Unbounded) ~fuel:(`Bounded 15) rules
          [%s (d x (1. + (y * x)))]  [%s y ];
        "dx/dy of ln x is 1 / x", `Quick,
        check_proves_equal ~node_limit:(`Bounded 100_000) ~fuel:(`Bounded 35) rules


### PR DESCRIPTION
Apply the same fix for the generic egraph implementation (and fix a small bug in both implementations). Added a few tests that previously would have previously failed to check that e-matching now has the correct behavior.