### PR TITLE
Typos

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -236,8 +236,8 @@ module L = struct
 ]}
 
 The first type we'll need to supply is a polymorphic type ['a shape], that
-captures the {i shape} of the expression langauge, with the type
-parameter ['a] encoding recursive occurances:
+captures the {i shape} of the expression language, with the type
+parameter ['a] encoding recursive occurrences:
 
 {[
 type 'a shape =
@@ -337,7 +337,7 @@ By separating out expressions into ['a shape] and their discriminants
 Loosely following Rust's egg library, {{:#top}Ego} allows users to run
 EClass analyses over its EGraphs - the idea here is that we can attach
 additional information to the equivalence classes in our EGraph, and
-then use this to perform more complex rewrites in a principaled way.
+then use this to perform more complex rewrites in a principled way.
 
 We can define EClass analyses in {{:#top}Ego} in two steps:
 
@@ -427,13 +427,13 @@ analysis. To do so, we'll need to define three functions:
   should generate a new abstract value for the node, usually using the
   abstract values of its children.
 
-- A [merge] operation, which is called whenever two equivalance
+- A [merge] operation, which is called whenever two equivalence
   classes are merged and should produce a new abstract value that
   represents the merge of their corresponding abstract values.
 
 - A [modify] operation, which is called whenever the children or
-  abstract values of an eclass are modified and may use the abstract
-  value of its to modify the egraph.
+  abstract values of an eclass are modified, and may modify the
+  egraph.
 
 Let's have a look at the implementation of each one of these
 operations for our constant folding analysis.

--- a/lib/basic.ml
+++ b/lib/basic.ml
@@ -70,7 +70,7 @@ type egraph = {
   class_members: (enode * Id.t) Vector.vector Id.Map.t; (* maps classes to the canonical nodes
                                                            they contain, and any classes that are
                                                            children of these nodes *)
-  hash_cons: (enode, Id.t) Hashtbl.t;                   (* maps cannonical nodes to their
+  hash_cons: (enode, Id.t) Hashtbl.t;                   (* maps canonical nodes to their
                                                            equivalence classes *)
   worklist: Id.t Vector.vector;                        (* List of equivalence classes for which
                                                           nodes are out of date - i.e
@@ -164,7 +164,7 @@ module EGraph = struct
       Id.Map.add self.class_members id cls;
       cls
 
-  (* Adds a node into the egraph, assuming that the cannonical version
+  (* Adds a node into the egraph, assuming that the canonical version
      of the node is up to date in the hash cons or 
   *)
   let add_enode self node =

--- a/lib/generic.ml
+++ b/lib/generic.ml
@@ -38,7 +38,7 @@ type ('node, 'analysis, 'data, 'permission) egraph = {
     ('node, 'data) eclass Id.Map.t;       (* maps classes to the canonical nodes
                                                                      they contain, and any classes that are
                                                                      children of these nodes *)
-  hash_cons: ('node, Id.t) Hashtbl.t;                  (* maps cannonical nodes to their
+  hash_cons: ('node, Id.t) Hashtbl.t;                  (* maps canonical nodes to their
                                                           equivalence classes *)
   pending: ('node * Id.t) Vector.vector;
 
@@ -289,7 +289,7 @@ struct
 
   let freeze (graph: (_, _, _, rw) egraph) = (graph:> (_, _, _, ro) egraph)
 
-  (* Adds a node into the egraph, assuming that the cannonical version
+  (* Adds a node into the egraph, assuming that the canonical version
      of the node is up to date in the hash cons or 
   *)
   let add_enode self (node: Id.t L.shape) =


### PR DESCRIPTION
I started looking at the `ego` codebase today (thanks for the nice project, and in particular the very carefully written documentation!), and noticed a few typos in the documentation and in a few code comments, which are fixed in this PR.
