### PR TITLE
Id: use a Vector/Dynarray instead of a hashtable

### DIFF
--- a/lib/ego.mli
+++ b/lib/ego.mli
@@ -21,7 +21,7 @@ module Id : sig
       data-structures provided by {!Ego}. *)
 
 
-  type t = private int
+  type t
   (** An abstract datatype used to represent equivalence classes in
       {!Ego}. *)
 

--- a/lib/equivalence.ml
+++ b/lib/equivalence.ml
@@ -5,54 +5,43 @@ module IntSet = CCHashSet.Make (Int)
 
 module Make  = functor () -> struct
 
-  type elem =
-    | Root
-    | Link of elem_ref
-  and elem_ref = int
-  and store = {
-    mutable limit: int;
-    content: elem IntMap.t
-  } 
+  type parent = Parent of idx [@@unboxed]
+  and idx = int
+  and store = parent Vector.vector
 
-  type t = elem_ref
+  type t = idx
 
   let repr v = v
 
-  let (.@[]) store rf = IntMap.find store.content rf
-  let (.@[]<-) store rf vl = IntMap.replace store.content rf vl
+  let (.@[]) = Vector.get
+  let (.@[]<-) = Vector.set
 
-  let create_store () = {limit=0; content=IntMap.create 100}
+  let create_store () = Vector.create ()
 
   let hash = Int.hash
 
   let make (store: store) () =
-    let x = store.limit in
-    store.limit <- x + 1;
-    IntMap.replace store.content x Root;
+    let x = Vector.length store in
+    Vector.push store (Parent x);
     x
 
   let rec find store x =
-    match store.@[x] with
-    | Root -> x
-    | Link y ->
+    let (Parent y) = store.@[x] in
+    if y = x then x
+    else begin
       let z = find store y in
-      if not @@ Equal.physical z y then
-        store.@[x] <- Link z;
+      if y <> z then store.@[x] <- Parent z;
       z
+    end
+
   let equal store t1 t2 =
     let t1 = find store t1 in
     let t2 = find store t2 in
-    Equal.physical t1 t2
+    Int.equal t1 t2
 
   let link store x y =
-    if Equal.physical x y then x
-    else match[@warning "-8"] store.@[x], store.@[y] with
-      | Root, Root -> store.@[y] <- Link x; x
-        (* if vx < vy then (store.@[x] <- Link y; y)
-         * else if vy > vx then (store.@[y] <- Link x; x)
-         * else (store.@[y] <- Link x;
-         *       store.@[x] <- make_raw ();
-         *       x) *)
+    if x <> y then store.@[y] <- Parent x;
+    x
 
   let union store x y =
     let x = find store x in

--- a/lib/equivalence.ml
+++ b/lib/equivalence.ml
@@ -6,7 +6,7 @@ module IntSet = CCHashSet.Make (Int)
 module Make  = functor () -> struct
 
   type elem =
-    | Root of int
+    | Root
     | Link of elem_ref
   and elem_ref = int
   and store = {
@@ -25,22 +25,15 @@ module Make  = functor () -> struct
 
   let hash = Int.hash
 
-  let rref (store: store) vl =
+  let make (store: store) () =
     let x = store.limit in
     store.limit <- x + 1;
-    IntMap.replace store.content x vl;
+    IntMap.replace store.content x Root;
     x
-
-  let make_raw =
-    let id = ref 0 in
-    fun () -> incr id; (Root !id)
-
-  let make store () =
-    rref store @@ make_raw ()
 
   let rec find store x =
     match store.@[x] with
-    | Root _ -> x
+    | Root -> x
     | Link y ->
       let z = find store y in
       if not @@ Equal.physical z y then
@@ -54,7 +47,7 @@ module Make  = functor () -> struct
   let link store x y =
     if Equal.physical x y then x
     else match[@warning "-8"] store.@[x], store.@[y] with
-      | Root _, Root _ -> store.@[y] <- Link x; x
+      | Root, Root -> store.@[y] <- Link x; x
         (* if vx < vy then (store.@[x] <- Link y; y)
          * else if vy > vx then (store.@[y] <- Link x; x)
          * else (store.@[y] <- Link x;

--- a/lib/equivalence.mli
+++ b/lib/equivalence.mli
@@ -1,6 +1,6 @@
 module Make : functor () -> sig
   type store
-  type t = private int
+  type t
 
   val repr : t -> int
   val create_store : unit -> store

--- a/lib/id.mli
+++ b/lib/id.mli
@@ -1,4 +1,4 @@
-type t = private int
+type t
 type store
 val eq_id : t -> t -> bool
 val repr : t -> int

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -13,7 +13,7 @@ module EClassId = struct
   let show = str pp
 
   let compare (a:t) (b: t) =
-    Int.compare (a :> int) (b :> int)
+    Int.compare (Id.repr a) (Id.repr b)
 
   let%test "IDs print correctly" =
     let store = Id.create_store () in


### PR DESCRIPTION
This gives a very nice speedup, a saturation benchmark becomes about 1.75x faster.

| Command |      Mean [s] |    Relative |
|:--------|--------------:|------------:|
| before  | 1.060 ± 0.100 | 1.73 ± 0.16 |
| after   | 0.614 ± 0.001 |        1.00 |
